### PR TITLE
feat(push dab): pass flags to the git push command

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -35,7 +35,10 @@ case "$1 $2" in
         ;;
     "push dab"*)
         detect_dab
-        git push
+        # Extract all arguments after "push dab" and pass them to git push
+        ARGS=("$@")
+        PUSH_ARGS=("${ARGS[@]:2}")  # Skip the first two arguments ("push" and "dab")
+        git push "${PUSH_ARGS[@]}"
         ;;
     "poulet"*)
         display_animation "$ANIMATIONS_FOLDER/poulet" $REPEAT_COUNT $PULL_FRAME_DELAY


### PR DESCRIPTION
Before:
When running git push dab -f, we received 
```
error: failed to push some refs to 'github.com:XXXX'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

Now:
 Correctly force pushed